### PR TITLE
config:show command tests and new "file" flag

### DIFF
--- a/src/Config/ConfigCommand.php
+++ b/src/Config/ConfigCommand.php
@@ -3,6 +3,7 @@
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Homesteader\Config\HomesteadConfig;
@@ -14,6 +15,16 @@ class ConfigCommand extends Command {
 	protected $homesteadConfig;
 	protected $questionHelper;
 
+    /**
+     * Add command configuration available to all config commands
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->addOption('file', 'f', InputOption::VALUE_OPTIONAL, 'Specifies custom path to Homestead config file.', null);
+    }
+
 	/**
 	 * Initializer for all config commands
 	 *
@@ -24,7 +35,7 @@ class ConfigCommand extends Command {
 	{
 		$this->input = $input;
 		$this->output = $output;
-		$this->homesteadConfig = new HomesteadConfig;
+		$this->homesteadConfig = new HomesteadConfig($input->getOption('file'));
 		$this->questionHelper = $this->getHelper('question');
 	}
 

--- a/src/Config/ConfigShowCommand.php
+++ b/src/Config/ConfigShowCommand.php
@@ -12,6 +12,7 @@ class ConfigShowCommand extends ConfigCommand {
 	 */
 	protected function configure()
 	{
+        parent::configure();
 		$this->setName('config:show');
 		$this->setDescription('Show current Homestead config settings.');
 	}
@@ -23,7 +24,7 @@ class ConfigShowCommand extends ConfigCommand {
      * @param OutputInterface $output
      * @internal param $ Symfony\Component\Console\Input\InputInterface
      * @internal param $ Symfony\Component\Console\Output\OutputInterface
-     * @return  void
+     * @return void
      */
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{

--- a/src/Config/HomesteadConfig.php
+++ b/src/Config/HomesteadConfig.php
@@ -36,7 +36,7 @@ class HomesteadConfig {
 	protected function findConfigFile()
 	{
 		if (isset($_SERVER['HOME'])) {
-			$this->configFilePath = $_SERVER['HOME'] . DIRECTORY_SEPARATOR . '.homestead/Homestead.yaml';
+            $this->configFilePath = $_SERVER['HOME'] . DIRECTORY_SEPARATOR . '.homestead/Homestead.yaml';
 		} else {
 			$this->configFilePath = $_SERVER['HOMEDRIVE'] . $_SERVER['HOMEPATH'] . DIRECTORY_SEPARATOR . '.homestead/Homestead.yaml';
 		}

--- a/tests/ConfigHomesteadConfigTest.php
+++ b/tests/ConfigHomesteadConfigTest.php
@@ -1,47 +1,19 @@
-<?php
+<?php require_once __DIR__.'/ConfigSetup.php';
 
 use Homesteader\Config\HomesteadConfig;
-use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\vfsStreamWrapper;
-use org\bovigo\vfs\vfsStreamDirectory;
 
-class ConfigHomesteadConfigTest extends \PHPUnit_Framework_TestCase {
-
-    protected $homesteadConfigFile = '.homestead/Homestead.yaml';
-
-    public function setUp()
-    {
-        vfsStreamWrapper::register();
-        $root = new vfsStreamDirectory('.homestead');
-        vfsStreamWrapper::setRoot($root);
-        $this->homesteadConfigFile = vfsStream::url('.homestead/Homestead.yaml');
-        $defaultHomesteadConfig = file_get_contents(dirname(__FILE__) . '/DefaultHomestead.yaml');
-        file_put_contents($this->homesteadConfigFile, $defaultHomesteadConfig);
-    }
-
-    public function tearDown()
-    {
-        if (file_exists($this->homesteadConfigFile)) {
-            unlink($this->homesteadConfigFile);
-        }
-    }
-
-    public function testVirtualFilesystemSetupHappened()
-    {
-        $this->assertFileExists($this->homesteadConfigFile);
-    }
-
+class ConfigHomesteadConfigTest extends ConfigSetup {
 
     public function testConfigFileOpensAsString()
     {
-        $configFile = new HomesteadConfig($this->homesteadConfigFile);
+        $configFile = new HomesteadConfig($this->homesteadConfigFilePath);
         $this->assertStringStartsWith('---', (string) $configFile);
         $this->assertStringStartsWith('---', $configFile->asString());
     }
 
     public function testConfigFileOpensAsArrayAndDataIsValid()
     {
-        $configFile = new HomesteadConfig($this->homesteadConfigFile);
+        $configFile = new HomesteadConfig($this->homesteadConfigFilePath);
         $this->assertArrayHasKey('ip', $configFile->asArray());
         $this->assertArrayHasKey('memory', $configFile->asArray());
         $this->assertArrayHasKey('cpus', $configFile->asArray());
@@ -52,5 +24,8 @@ class ConfigHomesteadConfigTest extends \PHPUnit_Framework_TestCase {
         $this->assertArrayHasKey('databases', $configFile->asArray());
         $this->assertArrayHasKey('variables', $configFile->asArray());
     }
+
+// @todo  Add tests for addTo() method
+// @todo  Add tests for save() method
 
 } 

--- a/tests/ConfigSetup.php
+++ b/tests/ConfigSetup.php
@@ -1,0 +1,57 @@
+<?php require_once __DIR__.'/../vendor/autoload.php';
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamWrapper;
+use org\bovigo\vfs\vfsStreamDirectory;
+
+class ConfigSetup extends \PHPUnit_Framework_TestCase
+{
+
+    const VFS_ROOT = '.homestead';
+    const VFS_CONFIG_FILENAME = 'Homestead.yaml';
+    const DEFAULT_CONFIG_FILENAME = 'DefaultHomestead.yaml'; // assumed same directory as this class
+
+    protected $homesteadConfigFilePath;
+
+    public function setUp()
+    {
+        $this->createVirtualFilesystem();
+        $this->createMockConfigFileFromDefault();
+    }
+
+    protected function createVirtualFilesystem()
+    {
+        vfsStreamWrapper::register();
+        $root = new vfsStreamDirectory(static::VFS_ROOT);
+        vfsStreamWrapper::setRoot($root);
+    }
+
+    protected function createMockConfigFileFromDefault()
+    {
+        $this->homesteadConfigFilePath = vfsStream::url(static::VFS_ROOT . '/' . static::VFS_CONFIG_FILENAME);
+        file_put_contents($this->homesteadConfigFilePath, $this->getDefaultConfigFileContents());
+    }
+
+    protected function getDefaultConfigFileContents()
+    {
+        return file_get_contents(dirname(__FILE__) . '/' . static::DEFAULT_CONFIG_FILENAME);
+    }
+
+    public function testMockConfigFileExists()
+    {
+        $this->assertFileExists($this->homesteadConfigFilePath);
+    }
+
+    public function testMockConfigFileContentsAreRight()
+    {
+        $this->assertEquals($this->getDefaultConfigFileContents(), file_get_contents($this->homesteadConfigFilePath));
+    }
+
+    public function tearDown()
+    {
+        if (file_exists($this->homesteadConfigFilePath)) {
+            unlink($this->homesteadConfigFilePath);
+        }
+    }
+
+}

--- a/tests/ConfigShowCommandTest.php
+++ b/tests/ConfigShowCommandTest.php
@@ -1,21 +1,21 @@
-<?php
+<?php require_once __DIR__.'/ConfigSetup.php';
 
-use Homesteader\Config\ConfigShowCommand;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Application;
+use Homesteader\Config\ConfigShowCommand;
 
-class ConfigShowCommandTest extends \PHPUnit_Framework_TestCase {
+class ConfigShowCommandTest extends ConfigSetup {
 	
-	public function testItOutputsRawConfigFile()
+	public function testItShouldOutputRawConfigFile()
 	{
-//		$application = new Application();
-//		$application->add(new ConfigShowCommand());
-//
-//		$command = $application->find('config:show');
-//		$commandTester = new CommandTester($command);
-//		$commandTester->execute([]);
-//
-//		$this->assertStringStartsWith('ip: ', $commandTester->getDisplay(), 'Homestead config file does not begin with "ip: "');
+		$application = new Application();
+		$application->add(new ConfigShowCommand());
+
+		$command = $application->find('config:show');
+		$commandTester = new CommandTester($command);
+		$commandTester->execute(['--file' => $this->homesteadConfigFilePath]);
+
+		$this->assertStringStartsWith('---', $commandTester->getDisplay(), 'Homestead config file does not begin with "ip: "');
 	}
 
 }


### PR DESCRIPTION
- 100% test coverage for `config:show`
- Added `--file path/to/custom/config.yaml` flag to all config commands
- Added ConfigSetup class to perform common tasks for config tests that all config command tests inherit from
