### PR TITLE
Help commands and config:new options/non-interactive mode

### DIFF
--- a/homesteader
+++ b/homesteader
@@ -5,6 +5,7 @@ require_once __DIR__.'/vendor/autoload.php';
 
 $app = new Symfony\Component\Console\Application('Homestead - Homestead Config Manager', '0.1.0');
 
+$app->add(new Homesteader\Config\ConfigListCommand);
 $app->add(new Homesteader\Config\ConfigShowCommand);
 $app->add(new Homesteader\Config\ConfigNewCommand);
 

--- a/src/Config/ConfigCommand.php
+++ b/src/Config/ConfigCommand.php
@@ -51,7 +51,7 @@ class ConfigCommand extends Command {
      * @throws \MissingValueException
      * @internal param $bool
      * @return string
-     * @todo  refactor this
+     * @todo refactor this... method's doing too much
      */
 	protected function prompt($promptText, $optionKeyOfDefault = null, $isRequired = false)
 	{
@@ -65,7 +65,7 @@ class ConfigCommand extends Command {
             if ($defaultAnswer != false) {
                 $promptText = $promptText . '[' . $defaultAnswer . ']: ';
             }
-            $prompt = new Question($promptText);
+            $prompt = new Question($promptText, $defaultAnswer);
             $answer = $this->questionHelper->ask($this->input, $this->output, $prompt);
         } else {
             $answer = $defaultAnswer;

--- a/src/Config/ConfigCommand.php
+++ b/src/Config/ConfigCommand.php
@@ -32,7 +32,7 @@ class ConfigCommand extends Command {
      * @param OutputInterface $output
      * @internal param $ Symfony\Component\Console\Input\InputInterface
      * @internal param $ Symfony\Component\Console\Output\OutputInterface
-     * @return void;
+     * @return void
      */
 	protected function execute(InputInterface $input, OutputInterface $output)
 	{
@@ -42,15 +42,18 @@ class ConfigCommand extends Command {
 		$this->questionHelper = $this->getHelper('question');
 	}
 
-	/**
-	 * Prompts for input if interaction enabled with option name default
-	 *
-	 * @param string
+    /**
+     * Prompts for input if interaction enabled with option name default
+     *
+     * @param $promptText
      * @param string
-	 * @return string
+     * @param bool $isRequired
+     * @throws \MissingValueException
+     * @internal param $bool
+     * @return string
      * @todo  refactor this
-	 */
-	protected function prompt($promptText, $optionKeyOfDefault = null)
+     */
+	protected function prompt($promptText, $optionKeyOfDefault = null, $isRequired = false)
 	{
         try {
             $defaultAnswer = $this->input->getOption($optionKeyOfDefault);
@@ -63,10 +66,16 @@ class ConfigCommand extends Command {
                 $promptText = $promptText . '[' . $defaultAnswer . ']: ';
             }
             $prompt = new Question($promptText);
-            return $this->questionHelper->ask($this->input, $this->output, $prompt);
+            $answer = $this->questionHelper->ask($this->input, $this->output, $prompt);
+        } else {
+            $answer = $defaultAnswer;
         }
 
-        return $defaultAnswer;
+        if ($isRequired === true && $answer == false) {
+            throw new \MissingValueException('Value required for prompt: "' . $promptText . '"');
+        }
+
+        return $answer;
 	}
 
 	/**

--- a/src/Config/ConfigListCommand.php
+++ b/src/Config/ConfigListCommand.php
@@ -33,26 +33,30 @@ class ConfigListCommand extends ConfigCommand {
         $this->output->writeln('');
         $this->output->writeln('The config commands allow for easy manipulation of the Homestead config file.');
         $this->output->writeln('');
-        $this->output->writeln('  <comment>config:show</comment>             Outputs the current config file to terminal.');
+        $this->output->writeln('  <comment>config:show</comment>               Outputs the current config file to terminal.');
         $this->output->writeln('');
-        $this->output->writeln('  Available options are included with example values.');
+        $this->output->writeln('  All config:new options are optional. You\'ll be prompted unless -n is set.');
         $this->output->writeln('');
-        $this->output->writeln('  <comment>config:new folder</comment>       Adds synced directory set.');
-        $this->output->writeln('    <info>--host</info>      (-h)      /path/to/host/dir');
-        $this->output->writeln('    <info>--homestead</info> (-g)      /path/on/homestead/to/dir');
+        $this->output->writeln('  <comment>config:new folder</comment>         Adds synced directory set.');
+        $this->output->writeln('    <info>--host</info>           (-h)     Path on your local system.');
+        $this->output->writeln('    <info>--homestead</info>      (-g)     Path in Homestead\'s filesystem.');
         $this->output->writeln('');
-        $this->output->writeln('  <comment>config:new site</comment>         Adds site and directory.');
-        $this->output->writeln('    <info>--domain</info>    (-d)      domaintoadd.com');
-        $this->output->writeln('    <info>--homestead</info> (-g)      /path/on/homestead/to/public/');
+        $this->output->writeln('  <comment>config:new site</comment>           Adds site and directory.');
+        $this->output->writeln('    <info>--domain</info>         (-d)     Local domain name of site.');
+        $this->output->writeln('    <info>--homestead</info>      (-g)     Path to public directory in Homestead.');
         $this->output->writeln('');
-        $this->output->writeln('  <comment>config:new variable</comment>     Adds variable.');
-        $this->output->writeln('    <info>--key</info>       (-k)      VAR');
-        $this->output->writeln('    <info>--value</info>     (-v)      VALUE');
+        $this->output->writeln('  <comment>config:new variable</comment>       Adds system variables.');
+        $this->output->writeln('    <info>--key</info>            (-k)      Name of variable.');
+        $this->output->writeln('    <info>--value</info>          (-v)      Value of variable.');
         $this->output->writeln('');
-        $this->output->writeln('  <comment>config:new database</comment>     Adds database.');
-        $this->output->writeln('    <info>--name</info>      (-n)      db_name');
+        $this->output->writeln('  <comment>config:new database</comment>       Adds database.');
+        $this->output->writeln('    <info>--name</info>           (-n)      Database name.');
         $this->output->writeln('');
-        $this->output->writeln('  Add -n for no interaction.');
+        $this->output->writeln('  <comment>Global Options:</comment>');
+        $this->output->writeln('    <info>--no-interaction</info> (-n)   No interaction (for unattended use).');
+        $this->output->writeln('    <info>--file</info>           (-f)   Custom config file path.');
+
+        $this->output->writeln('  ');
         $this->output->writeln('');
     }
 

--- a/src/Config/ConfigListCommand.php
+++ b/src/Config/ConfigListCommand.php
@@ -1,0 +1,59 @@
+<?php namespace Homesteader\Config;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ConfigListCommand extends ConfigCommand {
+
+    /**
+     * Configure command
+     *
+     * @return  void
+     */
+    protected function configure()
+    {
+        parent::configure();
+        $this->setName('config');
+        $this->setDescription('Shows available config commands.');
+    }
+
+    /**
+     * Initialize the command
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @internal param $ Symfony\Component\Console\Input\InputInterface
+     * @internal param $ Symfony\Component\Console\Output\OutputInterface
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        parent::execute($input, $output);
+
+        $this->output->writeln('');
+        $this->output->writeln('The config commands allow for easy manipulation of the Homestead config file.');
+        $this->output->writeln('');
+        $this->output->writeln('  <comment>config:show</comment>             Outputs the current config file to terminal.');
+        $this->output->writeln('');
+        $this->output->writeln('  Available options are included with example values.');
+        $this->output->writeln('');
+        $this->output->writeln('  <comment>config:new folder</comment>       Adds synced directory set.');
+        $this->output->writeln('    <info>--host</info>      (-h)      /path/to/host/dir');
+        $this->output->writeln('    <info>--homestead</info> (-g)      /path/on/homestead/to/dir');
+        $this->output->writeln('');
+        $this->output->writeln('  <comment>config:new site</comment>         Adds site and directory.');
+        $this->output->writeln('    <info>--domain</info>    (-d)      domaintoadd.com');
+        $this->output->writeln('    <info>--homestead</info> (-g)      /path/on/homestead/to/public/');
+        $this->output->writeln('');
+        $this->output->writeln('  <comment>config:new variable</comment>     Adds variable.');
+        $this->output->writeln('    <info>--key</info>       (-k)      VAR');
+        $this->output->writeln('    <info>--value</info>     (-v)      VALUE');
+        $this->output->writeln('');
+        $this->output->writeln('  <comment>config:new database</comment>     Adds database.');
+        $this->output->writeln('    <info>--name</info>      (-n)      db_name');
+        $this->output->writeln('');
+        $this->output->writeln('  Add -n for no interaction.');
+        $this->output->writeln('');
+    }
+
+}

--- a/src/Config/ConfigListCommand.php
+++ b/src/Config/ConfigListCommand.php
@@ -38,7 +38,7 @@ class ConfigListCommand extends ConfigCommand {
         $this->output->writeln('  All config:new options are optional. You\'ll be prompted unless -n is set.');
         $this->output->writeln('');
         $this->output->writeln('  <comment>config:new folder</comment>         Adds synced directory set.');
-        $this->output->writeln('    <info>--host</info>           (-h)     Path on your local system.');
+        $this->output->writeln('    <info>--host</info>           (-o)     Path on your local system.');
         $this->output->writeln('    <info>--homestead</info>      (-g)     Path in Homestead\'s filesystem.');
         $this->output->writeln('');
         $this->output->writeln('  <comment>config:new site</comment>           Adds site and directory.');
@@ -47,10 +47,10 @@ class ConfigListCommand extends ConfigCommand {
         $this->output->writeln('');
         $this->output->writeln('  <comment>config:new variable</comment>       Adds system variables.');
         $this->output->writeln('    <info>--key</info>            (-k)      Name of variable.');
-        $this->output->writeln('    <info>--value</info>          (-v)      Value of variable.');
+        $this->output->writeln('    <info>--value</info>          (-a)      Value of variable.');
         $this->output->writeln('');
         $this->output->writeln('  <comment>config:new database</comment>       Adds database.');
-        $this->output->writeln('    <info>--name</info>           (-n)      Database name.');
+        $this->output->writeln('    <info>--name</info>           (-b)      Database name.');
         $this->output->writeln('');
         $this->output->writeln('  <comment>Global Options:</comment>');
         $this->output->writeln('    <info>--no-interaction</info> (-n)   No interaction (for unattended use).');

--- a/src/Config/ConfigListCommand.php
+++ b/src/Config/ConfigListCommand.php
@@ -28,35 +28,33 @@ class ConfigListCommand extends ConfigCommand {
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        parent::execute($input, $output);
-
-        $this->output->writeln('');
-        $this->output->writeln('The config commands allow for easy manipulation of the Homestead config file.');
-        $this->output->writeln('');
-        $this->output->writeln('  <comment>config:show</comment>               Outputs the current config file to terminal.');
-        $this->output->writeln('');
-        $this->output->writeln('  All config:new options are optional. You\'ll be prompted unless -n is set.');
-        $this->output->writeln('');
-        $this->output->writeln('  <comment>config:new folder</comment>         Adds synced directory set.');
-        $this->output->writeln('    <info>--host</info>           (-o)     Path on your local system.');
-        $this->output->writeln('    <info>--homestead</info>      (-g)     Path in Homestead\'s filesystem.');
-        $this->output->writeln('');
-        $this->output->writeln('  <comment>config:new site</comment>           Adds site and directory.');
-        $this->output->writeln('    <info>--domain</info>         (-d)     Local domain name of site.');
-        $this->output->writeln('    <info>--homestead</info>      (-g)     Path to public directory in Homestead.');
-        $this->output->writeln('');
-        $this->output->writeln('  <comment>config:new variable</comment>       Adds system variables.');
-        $this->output->writeln('    <info>--key</info>            (-k)      Name of variable.');
-        $this->output->writeln('    <info>--value</info>          (-a)      Value of variable.');
-        $this->output->writeln('');
-        $this->output->writeln('  <comment>config:new database</comment>       Adds database.');
-        $this->output->writeln('    <info>--name</info>           (-b)      Database name.');
-        $this->output->writeln('');
-        $this->output->writeln('  <comment>Global Options:</comment>');
-        $this->output->writeln('    <info>--no-interaction</info> (-n)   No interaction (for unattended use).');
-        $this->output->writeln('    <info>--file</info>           (-f)   Custom config file path.');
-        $this->output->writeln('');
-        $this->output->writeln('');
+        $output->writeln('');
+        $output->writeln('The config commands allow for easy manipulation of the Homestead config file.');
+        $output->writeln('');
+        $output->writeln('  <comment>config:show</comment>               Outputs the current config file to terminal.');
+        $output->writeln('');
+        $output->writeln('  All config:new options are optional. You\'ll be prompted unless -n is set.');
+        $output->writeln('');
+        $output->writeln('  <comment>config:new folder</comment>         Adds synced directory set.');
+        $output->writeln('    <info>--host</info>           (-o)     Path on your local system.');
+        $output->writeln('    <info>--homestead</info>      (-g)     Path in Homestead\'s filesystem.');
+        $output->writeln('');
+        $output->writeln('  <comment>config:new site</comment>           Adds site and directory.');
+        $output->writeln('    <info>--domain</info>         (-d)     Local domain name of site.');
+        $output->writeln('    <info>--homestead</info>      (-g)     Path to public directory in Homestead.');
+        $output->writeln('');
+        $output->writeln('  <comment>config:new variable</comment>       Adds system variables.');
+        $output->writeln('    <info>--key</info>            (-k)      Name of variable.');
+        $output->writeln('    <info>--value</info>          (-a)      Value of variable.');
+        $output->writeln('');
+        $output->writeln('  <comment>config:new database</comment>       Adds database.');
+        $output->writeln('    <info>--name</info>           (-b)      Database name.');
+        $output->writeln('');
+        $output->writeln('  <comment>Global Options:</comment>');
+        $output->writeln('    <info>--no-interaction</info> (-n)   No interaction (for unattended use).');
+        $output->writeln('    <info>--file</info>           (-f)   Custom config file path.');
+        $output->writeln('');
+        $output->writeln('');
     }
 
 }

--- a/src/Config/ConfigListCommand.php
+++ b/src/Config/ConfigListCommand.php
@@ -55,8 +55,7 @@ class ConfigListCommand extends ConfigCommand {
         $this->output->writeln('  <comment>Global Options:</comment>');
         $this->output->writeln('    <info>--no-interaction</info> (-n)   No interaction (for unattended use).');
         $this->output->writeln('    <info>--file</info>           (-f)   Custom config file path.');
-
-        $this->output->writeln('  ');
+        $this->output->writeln('');
         $this->output->writeln('');
     }
 

--- a/src/Config/ConfigNewCommand.php
+++ b/src/Config/ConfigNewCommand.php
@@ -51,7 +51,7 @@ class ConfigNewCommand extends ConfigCommand {
                 break;
 			default:
 				$helpCommand = $this->getApplication()->find('config:new');
-                $input = new ArrayInput(['key' => 'list']);
+                $input = new ArrayInput(['key' => 'list', '--file' => $input->getOption('file')]);
                 $helpCommand->run($input, $output);
 				break;
 		}

--- a/src/Config/ConfigNewCommand.php
+++ b/src/Config/ConfigNewCommand.php
@@ -1,5 +1,6 @@
 <?php namespace Homesteader\Config;
 
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,7 +17,7 @@ class ConfigNewCommand extends ConfigCommand {
         parent::configure();
 		$this->setName('config:new');
 		$this->setDescription('Add a new item to the Homestead config.');
-		$this->addArgument('key', InputArgument::OPTIONAL, 'Type of config to add.');
+		$this->addArgument('key', InputArgument::OPTIONAL, 'Type of config to add. [folder|site|database|variable]');
 	}
 
     /**
@@ -42,11 +43,16 @@ class ConfigNewCommand extends ConfigCommand {
 			case 'database':
 				$this->newDatabase();
 				break;
-			case ('variable'):
+			case 'variable':
 				$this->newVariable();
 				break;
+            case 'list':
+                $this->listKeys();
+                break;
 			default:
-				$this->output->writeln('<error>Invalid entry!</error>');
+				$helpCommand = $this->getApplication()->find('config:new');
+                $input = new ArrayInput(['key' => 'list']);
+                $helpCommand->run($input, $output);
 				break;
 		}
 	}
@@ -158,5 +164,31 @@ class ConfigNewCommand extends ConfigCommand {
 
 		$this->homesteadConfigSave();
 	}
+
+    protected function listKeys()
+    {
+        $this->output->writeln('');
+        $this->output->writeln('Adds new config options to the Homestead config file.');
+        $this->output->writeln('');
+        $this->output->writeln('  Available options are included with example values.');
+        $this->output->writeln('');
+        $this->output->writeln('  <comment>config:new folder</comment>       Adds synced directory set');
+        $this->output->writeln('    <info>--host</info>      (-h)      /path/to/host/dir');
+        $this->output->writeln('    <info>--homestead</info> (-g)      /path/on/homestead/to/dir');
+        $this->output->writeln('');
+        $this->output->writeln('  <comment>config:new site</comment>         Adds site and directory');
+        $this->output->writeln('    <info>--domain</info>    (-d)      domaintoadd.com');
+        $this->output->writeln('    <info>--homestead</info> (-g)      /path/on/homestead/to/public/');
+        $this->output->writeln('');
+        $this->output->writeln('  <comment>config:new variable</comment>     Adds variable');
+        $this->output->writeln('    <info>--key</info>       (-k)      VAR');
+        $this->output->writeln('    <info>--value</info>     (-v)      VALUE');
+        $this->output->writeln('');
+        $this->output->writeln('  <comment>config:new database</comment>     Adds database');
+        $this->output->writeln('    <info>--name</info>      (-n)      db_name');
+        $this->output->writeln('');
+        $this->output->writeln('  Add -n for no interaction.');
+        $this->output->writeln('');
+    }
 
 }

--- a/src/Config/ConfigNewCommand.php
+++ b/src/Config/ConfigNewCommand.php
@@ -73,8 +73,8 @@ class ConfigNewCommand extends ConfigCommand {
 	 */
 	protected function newFolder()
 	{
-        $hostFolder = $this->prompt('Path to host machine (not Homestead) directory: ', 'host');
-		$homesteadFolder = $this->prompt('Path to internal Homestead directory: ', 'homestead');
+        $hostFolder = $this->prompt('Path to host machine (not Homestead) directory: ', 'host', true);
+		$homesteadFolder = $this->prompt('Path to internal Homestead directory: ', 'homestead', true);
 
         $changesConfirmed = $this->confirmChanges("About to sync <info>{$hostFolder}</info> to <info>{$homesteadFolder}</info> in Homestead config.");
 		if ($changesConfirmed === false) {
@@ -100,8 +100,8 @@ class ConfigNewCommand extends ConfigCommand {
 	 */
 	protected function newSite()
 	{
-        $domainName = $this->prompt('Domain name: ', 'domain');
-        $homesteadWebRoot = $this->prompt('Path to web root in Homestead: ', 'homestead');
+        $domainName = $this->prompt('Domain name: ', 'domain', true);
+        $homesteadWebRoot = $this->prompt('Path to web root in Homestead: ', 'homestead', true);
 
         $changesConfirmed = $this->confirmChanges("About to point <info>{$domainName}</info> to <info>{$homesteadWebRoot}</info> in Homestead config.");
         if ($changesConfirmed === false) {
@@ -127,8 +127,8 @@ class ConfigNewCommand extends ConfigCommand {
 	 */
 	protected function newVariable()
 	{
-        $variableKey = $this->prompt('Variable key: ', 'key');
-		$variableValue = $this->prompt('Variable value: ', 'value');
+        $variableKey = $this->prompt('Variable key: ', 'key', true);
+		$variableValue = $this->prompt('Variable value: ', 'value', true);
 
 		$changesConfirmed = $this->confirmChanges("About to add environmental variable <info>{$variableKey}</info> = <info>{$variableValue}</info> in Homestead config.");
 		if ($changesConfirmed === false) {
@@ -154,7 +154,7 @@ class ConfigNewCommand extends ConfigCommand {
 	 */
 	protected function newDatabase()
 	{
-		$databaseName = $this->prompt('Database name: ', 'name');
+		$databaseName = $this->prompt('Database name: ', 'name', true);
 
 		$changesConfirmed = $this->confirmChanges("About to add <info>{$databaseName}</info> to Homestead config.");
 		if ($changesConfirmed === false) {

--- a/src/Config/ConfigNewCommand.php
+++ b/src/Config/ConfigNewCommand.php
@@ -18,7 +18,13 @@ class ConfigNewCommand extends ConfigCommand {
 		$this->setName('config:new');
 		$this->setDescription('Add a new item to the Homestead config.');
 		$this->addArgument('key', InputArgument::OPTIONAL, 'Type of config to add. [folder|site|database|variable]');
-	}
+	    $this->addOption('host', 'o', InputArgument::OPTIONAL, 'Path on your local machine.');
+        $this->addOption('homestead', 'g', InputArgument::OPTIONAL, 'Path in Homestead\'s filesystem.');
+        $this->addOption('domain', 'd', InputArgument::OPTIONAL, 'Local domain name of site.');
+        $this->addOption('key', 'k', InputArgument::OPTIONAL, 'Name of variable.');
+        $this->addOption('value', 'a', InputArgument::OPTIONAL, 'Value of variable.');
+        $this->addOption('name', 'b', InputArgument::OPTIONAL, 'Database name.');
+    }
 
     /**
      * Initialize the command and determine which path to take
@@ -64,14 +70,13 @@ class ConfigNewCommand extends ConfigCommand {
 	 * homesteader config:new folder
 	 *
 	 * @return void
-     * @todo  Write test for changes not confirmed
 	 */
 	protected function newFolder()
 	{
-		$hostFolder = $this->prompt('Path to host machine (not Homestead) directory: ');
-		$homesteadFolder = $this->prompt('Path to internal Homestead directory: ');
+        $hostFolder = $this->prompt('Path to host machine (not Homestead) directory: ', 'host');
+		$homesteadFolder = $this->prompt('Path to internal Homestead directory: ', 'homestead');
 
-		$changesConfirmed = $this->confirmChanges("About to sync <info>{$hostFolder}</info> to <info>{$homesteadFolder}</info> in Homestead config.");
+        $changesConfirmed = $this->confirmChanges("About to sync <info>{$hostFolder}</info> to <info>{$homesteadFolder}</info> in Homestead config.");
 		if ($changesConfirmed === false) {
             $this->outputChangesCanceled();
 			return;
@@ -83,7 +88,7 @@ class ConfigNewCommand extends ConfigCommand {
 		]);
 
 		$this->homesteadConfigSave();
-	}
+    }
 
 	/**
 	 * Add new sites config set to config file
@@ -92,18 +97,17 @@ class ConfigNewCommand extends ConfigCommand {
 	 * homesteader config:new site
 	 *
 	 * @return void
-     * @todo  Write test for changes not confirmed
 	 */
 	protected function newSite()
 	{
-		$domainName = $this->prompt('Domain name: ');
-		$homesteadWebRoot = $this->prompt('Path to web root in Homestead: ');
+        $domainName = $this->prompt('Domain name: ', 'domain');
+        $homesteadWebRoot = $this->prompt('Path to web root in Homestead: ', 'homestead');
 
-		$changesConfirmed = $this->confirmChanges("About to point <info>{$domainName}</info> to <info>{$homesteadWebRoot}</info> in Homestead config.");
-		if ($changesConfirmed === false) {
-			$this->outputChangesCanceled();
+        $changesConfirmed = $this->confirmChanges("About to point <info>{$domainName}</info> to <info>{$homesteadWebRoot}</info> in Homestead config.");
+        if ($changesConfirmed === false) {
+            $this->outputChangesCanceled();
             return;
-		}
+        }
 
 		$this->homesteadConfig->addTo('sites', [
 			'map' => $domainName,
@@ -120,12 +124,11 @@ class ConfigNewCommand extends ConfigCommand {
 	 * homesteader config:new var|variable
 	 *
 	 * @return void
-     * @todo  Write test for changes not confirmed
 	 */
 	protected function newVariable()
 	{
-		$variableKey = $this->prompt('Variable key: ');
-		$variableValue = $this->prompt('Variable value: ');
+        $variableKey = $this->prompt('Variable key: ', 'key');
+		$variableValue = $this->prompt('Variable value: ', 'value');
 
 		$changesConfirmed = $this->confirmChanges("About to add environmental variable <info>{$variableKey}</info> = <info>{$variableValue}</info> in Homestead config.");
 		if ($changesConfirmed === false) {
@@ -148,11 +151,10 @@ class ConfigNewCommand extends ConfigCommand {
 	 * homesteader config:new database
 	 *
 	 * @return void
-     * @todo  Write test for changes not confirmed
 	 */
 	protected function newDatabase()
 	{
-		$databaseName = $this->prompt('Database name: ');
+		$databaseName = $this->prompt('Database name: ', 'name');
 
 		$changesConfirmed = $this->confirmChanges("About to add <info>{$databaseName}</info> to Homestead config.");
 		if ($changesConfirmed === false) {

--- a/src/Exceptions.php
+++ b/src/Exceptions.php
@@ -2,3 +2,4 @@
 
 class ConfigFileIOException extends Exception {}
 class ConfigFileInvalidKeyException extends Exception {}
+class MissingValueException extends Exception {}

--- a/tests/ConfigHomesteadConfigTest.php
+++ b/tests/ConfigHomesteadConfigTest.php
@@ -82,7 +82,5 @@ class ConfigHomesteadConfigTest extends ConfigSetup {
         new HomesteadConfig($this->homesteadConfigFilePath);
     }
 
-// @todo  Add tests for addTo() method
-// @todo  Add tests for save() method
 
 } 

--- a/tests/ConfigListCommandTest.php
+++ b/tests/ConfigListCommandTest.php
@@ -1,0 +1,21 @@
+<?php require_once __DIR__.'/ConfigSetup.php';
+
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Console\Application;
+use Homesteader\Config\ConfigListCommand;
+
+class ConfigListCommandTest extends ConfigSetup {
+
+    public function testItShouldOutputListOfOptions()
+    {
+        $application = new Application();
+        $application->add(new ConfigListCommand());
+
+        $command = $application->find('config');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $this->assertStringStartsWith(PHP_EOL . 'The config commands allow for easy manipulation of the Homestead config file.', $commandTester->getDisplay());
+    }
+
+}

--- a/tests/ConfigListCommandTest.php
+++ b/tests/ConfigListCommandTest.php
@@ -13,7 +13,9 @@ class ConfigListCommandTest extends ConfigSetup {
 
         $command = $application->find('config');
         $commandTester = new CommandTester($command);
-        $commandTester->execute([]);
+        $commandTester->execute([
+            '--file' => $this->homesteadConfigFilePath
+        ]);
 
         $this->assertStringStartsWith(PHP_EOL . 'The config commands allow for easy manipulation of the Homestead config file.', $commandTester->getDisplay());
     }

--- a/tests/ConfigNewCommandTest.php
+++ b/tests/ConfigNewCommandTest.php
@@ -9,7 +9,7 @@ use Homesteader\Config\HomesteadConfig;
 
 class ConfigNewCommandTest extends ConfigSetup {
 
-//    @todo refactor these tests... lots of repetition
+    // @todo refactor these tests... lots of repetition
 
     protected $app;
 
@@ -67,6 +67,27 @@ class ConfigNewCommandTest extends ConfigSetup {
         $this->assertEquals($this->getDefaultConfigFileContents(), $savedConfigFile);
     }
 
+    public function testItShouldCreateNewFolderWithNoInteraction()
+    {
+        $command = $this->app->find('config:new');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'key' => 'folder',
+            '--file' => $this->homesteadConfigFilePath,
+            '--host' => '/Users/user/Projects/TestAppName',
+            '--homestead' => '/home/vagrant/TestAppName'
+        ], ['interactive' => false]);
+
+        $savedConfigFile = new HomesteadConfig($this->homesteadConfigFilePath);
+        $savedConfigFile = $savedConfigFile->asArray();
+
+        $this->assertStringEndsWith("Homestead config file successfully updated.\n", $commandTester->getDisplay());
+        $this->assertCount(9, $savedConfigFile);
+        $this->assertCount(2, $savedConfigFile['folders']);
+        $this->assertEquals('/Users/user/Projects/TestAppName', $savedConfigFile['folders'][1]['map']);
+        $this->assertEquals('/home/vagrant/TestAppName', $savedConfigFile['folders'][1]['to']);
+    }
+
     public function testItShouldCreateNewSite()
     {
         $command = $this->app->find('config:new');
@@ -81,6 +102,27 @@ class ConfigNewCommandTest extends ConfigSetup {
             'key' => 'site',
             '--file' => $this->homesteadConfigFilePath
         ]);
+
+        $savedConfigFile = new HomesteadConfig($this->homesteadConfigFilePath);
+        $savedConfigFile = $savedConfigFile->asArray();
+
+        $this->assertStringEndsWith("Homestead config file successfully updated.\n", $commandTester->getDisplay());
+        $this->assertCount(9, $savedConfigFile);
+        $this->assertCount(2, $savedConfigFile['sites']);
+        $this->assertEquals('test-app.local', $savedConfigFile['sites'][1]['map']);
+        $this->assertEquals('/home/vagrant/test-app', $savedConfigFile['sites'][1]['to']);
+    }
+
+    public function testItShouldCreateNewSiteWithNoInteraction()
+    {
+        $command = $this->app->find('config:new');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'key' => 'site',
+            '--file' => $this->homesteadConfigFilePath,
+            '--domain' => 'test-app.local',
+            '--homestead' => '/home/vagrant/test-app'
+        ], ['interactive' => false]);
 
         $savedConfigFile = new HomesteadConfig($this->homesteadConfigFilePath);
         $savedConfigFile = $savedConfigFile->asArray();
@@ -139,6 +181,27 @@ class ConfigNewCommandTest extends ConfigSetup {
         $this->assertEquals('test_value', $savedConfigFile['variables'][1]['value']);
     }
 
+    public function testItShouldCreateNewVariableWithNoInteraction()
+    {
+        $command = $this->app->find('config:new');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'key' => 'variable',
+            '--file' => $this->homesteadConfigFilePath,
+            '--key' => 'TEST_VAR',
+            '--value' => 'test_value'
+        ], ['interactive' => false]);
+
+        $savedConfigFile = new HomesteadConfig($this->homesteadConfigFilePath);
+        $savedConfigFile = $savedConfigFile->asArray();
+
+        $this->assertStringEndsWith("Homestead config file successfully updated.\n", $commandTester->getDisplay());
+        $this->assertCount(9, $savedConfigFile);
+        $this->assertCount(2, $savedConfigFile['variables']);
+        $this->assertEquals('TEST_VAR', $savedConfigFile['variables'][1]['key']);
+        $this->assertEquals('test_value', $savedConfigFile['variables'][1]['value']);
+    }
+
     public function testItShouldCancelChangesWhenOnNewVariable()
     {
         $command = $this->app->find('config:new');
@@ -184,6 +247,25 @@ class ConfigNewCommandTest extends ConfigSetup {
         $this->assertEquals('test_db', $savedConfigFile['databases'][1]);
     }
 
+    public function testItShouldCreateNewDatabaseWithNoInteraction()
+    {
+        $command = $this->app->find('config:new');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'key' => 'database',
+            '--file' => $this->homesteadConfigFilePath,
+            '--name' => 'test_db'
+        ], ['interactive' => false]);
+
+        $savedConfigFile = new HomesteadConfig($this->homesteadConfigFilePath);
+        $savedConfigFile = $savedConfigFile->asArray();
+
+        $this->assertStringEndsWith("Homestead config file successfully updated.\n", $commandTester->getDisplay());
+        $this->assertCount(9, $savedConfigFile);
+        $this->assertCount(2, $savedConfigFile['databases']);
+        $this->assertEquals('test_db', $savedConfigFile['databases'][1]);
+    }
+    
     public function testItShouldCancelChangesWhenOnNewDatabase()
     {
         $command = $this->app->find('config:new');

--- a/tests/ConfigNewCommandTest.php
+++ b/tests/ConfigNewCommandTest.php
@@ -265,7 +265,7 @@ class ConfigNewCommandTest extends ConfigSetup {
         $this->assertCount(2, $savedConfigFile['databases']);
         $this->assertEquals('test_db', $savedConfigFile['databases'][1]);
     }
-    
+
     public function testItShouldCancelChangesWhenOnNewDatabase()
     {
         $command = $this->app->find('config:new');

--- a/tests/ConfigNewCommandTest.php
+++ b/tests/ConfigNewCommandTest.php
@@ -88,6 +88,17 @@ class ConfigNewCommandTest extends ConfigSetup {
         $this->assertEquals('/home/vagrant/TestAppName', $savedConfigFile['folders'][1]['to']);
     }
 
+    public function testItShouldThrowExceptionIfMissingValues()
+    {
+        $command = $this->app->find('config:new');
+        $commandTester = new CommandTester($command);
+        $this->setExpectedException('MissingValueException', 'Value required for prompt: "Path to host machine (not Homestead) directory: "');
+        $commandTester->execute([
+            'key' => 'folder',
+            '--file' => $this->homesteadConfigFilePath
+        ], ['interactive' => false]);
+    }
+
     public function testItShouldCreateNewSite()
     {
         $command = $this->app->find('config:new');

--- a/tests/ConfigNewCommandTest.php
+++ b/tests/ConfigNewCommandTest.php
@@ -214,7 +214,7 @@ class ConfigNewCommandTest extends ConfigSetup {
             '--file' => $this->homesteadConfigFilePath
         ]);
 
-        $this->assertStringEndsWith("Invalid entry!\n", $commandTester->getDisplay());
+        $this->assertStringStartsWith(PHP_EOL . "Adds new config options to the Homestead config file.", $commandTester->getDisplay());
     }
 
     public function testItShouldHandleNoKeyEntry()
@@ -225,7 +225,7 @@ class ConfigNewCommandTest extends ConfigSetup {
             '--file' => $this->homesteadConfigFilePath
         ]);
 
-        $this->assertStringEndsWith("Invalid entry!\n", $commandTester->getDisplay());
+        $this->assertStringStartsWith(PHP_EOL . "Adds new config options to the Homestead config file.", $commandTester->getDisplay());
     }
 
 }


### PR DESCRIPTION
- Made prompt method be able to require input
- Prompt method can now default to an input option
- Prompt method and confirm changes are now aware of interactive mode
- Added `config:list` command (displays when `config` is entered)
- Added `config:new list` command (displays when `config:new` is entered)
- Added options to config new command (this is what prompted need to abstract new commands into their own classes)
- Added tests for all of the above (at 98% coverage)
